### PR TITLE
Use two dashes in `npm install nsp --global`

### DIFF
--- a/views/tools.jade
+++ b/views/tools.jade
@@ -17,7 +17,7 @@ block content
         p nsp is the main command line interface to the Node Security Project. It allows for auditing a package.json or npm-shrinkwrap.json file against the API.
         h4 Installation
         pre
-          code npm install nsp -global
+          code npm install nsp --global
         h4 Example Usage
         p From inside your project directory
         pre


### PR DESCRIPTION
It seems like it still works with a single dash but it's uncommon AFAIK and the `npm --save` command a few lines below uses two dashes, so it makes sense to unify.