### PR TITLE
Docs: show how to use nsp-gulp behind the Proxy

### DIFF
--- a/views/tools.jade
+++ b/views/tools.jade
@@ -51,6 +51,7 @@ block content
             |     stopOnError: false
             |   }, cb);
             | });
+            | &nbsp;
             | //For enterprises building behind a proxy (HTTP_PROXY or HTTPS_PROXY), use the proxy option:
             | gulp.task('nsp', function (cb) {
             |   gulpNSP({

--- a/views/tools.jade
+++ b/views/tools.jade
@@ -51,3 +51,10 @@ block content
             |     stopOnError: false
             |   }, cb);
             | });
+            | //For enterprises building behind a proxy (HTTP_PROXY or HTTPS_PROXY), use the proxy option:
+            | gulp.task('nsp', function (cb) {
+            |   gulpNSP({
+            |     shrinkwrap: __dirname + '/npm-shrinkwrap.json',
+            |     proxy: process.env.HTTPS_PROXY
+            |   }, cb);
+            | });


### PR DESCRIPTION
Problem
----

Following the instructions from the tools page leads to errors if the user assumes the nsp API will use the HTTP_PROXY. The build fails with the following error, without any indication that there's no connectivity to the NSP server.

```js
[23:09:39] Starting 'nsp'...
[23:09:39]        INTUIT SECURITY CHECK - NSP        
[23:09:39] Scanning type: package /jenkins-home/var-lib-jenkins/jobs/BUILD-ISP-isp/branches/master/workspace/package.json

/jenkins-home/var-lib-jenkins/jobs/BUILD-ISP-isp/branches/master/workspace/node_modules/sp-quality/node_modules/gulp-nsp/index.js:27
    if (params.stopOnError === false || data.length === 0) {
                                            ^
TypeError: Cannot read property 'length' of undefined
    at /jenkins-home/var-lib-jenkins/jobs/BUILD-ISP-isp/branches/master/workspace/node_modules/sp-quality/node_modules/gulp-nsp/index.js:27:45
    at /jenkins-home/var-lib-jenkins/jobs/BUILD-ISP-isp/branches/master/workspace/node_modules/sp-quality/node_modules/gulp-nsp/node_modules/nsp/lib/check.js:207:16
    at /jenkins-home/var-lib-jenkins/jobs/BUILD-ISP-isp/branches/master/workspace/node_modules/sp-quality/node_modules/gulp-nsp/node_modules/nsp/node_modules/wreck/lib/index.js:467:20
    at finish (/jenkins-home/var-lib-jenkins/jobs/BUILD-ISP-isp/branches/master/workspace/node_modules/sp-quality/node_modules/gulp-nsp/node_modules/nsp/node_modules/wreck/lib/index.js:144:20)
    at wrapped (/jenkins-home/var-lib-jenkins/jobs/BUILD-ISP-isp/branches/master/workspace/node_modules/sp-quality/node_modules/gulp-nsp/node_modules/nsp/node_modules/hoek/lib/index.js:866:20)
    at ClientRequest.onError (/jenkins-home/var-lib-jenkins/jobs/BUILD-ISP-isp/branches/master/workspace/node_modules/sp-quality/node_modules/gulp-nsp/node_modules/nsp/node_modules/wreck/lib/index.js:153:16)
    at ClientRequest.g (events.js:180:16)
    at ClientRequest.emit (events.js:95:17)
    at CleartextStream.socketErrorListener (http.js:1548:9)
    at CleartextStream.emit (events.js:95:17)
    at Socket.onerror (tls.js:1456:17)
    at Socket.emit (events.js:117:20)
```

Solution
-----

1. Add documentation showing how to setup the proxy settings so that users don't assume this setting.
2. File a ticket with the API team to properly report lack of connectivity when trying to pull NSP advisories.

I'm taking a stab on (1) since this is simpler... I could properly run the checks after the proxy settings.